### PR TITLE
Feature: re-order message content and put time always at the start

### DIFF
--- a/features/sell-history.ts
+++ b/features/sell-history.ts
@@ -35,10 +35,13 @@ export default function setup(client: Client, historyChannelId: string, region: 
 
             if (sellMessages) {
               for (const sellMessage of sellMessages.values()) {
+                const match = getTimestampMatch(sellMessage.content)
+                const timeText = extractTimeText(match)
+                const timestamp = extractTimestamp(match)
                 history.push({
                   id: sellMessage.id,
-                  date: extractTimestamp(sellMessage.content),
-                  text: sellMessage.content,
+                  date: timestamp,
+                  text: getSortedMessage(sellMessage.content, timeText),
                 })
               }
             }
@@ -73,10 +76,13 @@ export default function setup(client: Client, historyChannelId: string, region: 
 
       if (sellChannels[message.channelId] && sellChannels[message.channelId].region === region) {
         if (message.content.includes('<t:')) {
+          const match = getTimestampMatch(sellMessage.content)
+          const timeText = extractTimeText(match)
+          const timestamp = extractTimestamp(match)
           history.push({
-            id: message.id,
-            date: extractTimestamp(message.content),
-            text: message.content,
+            id: sellMessage.id,
+            date: timestamp,
+            text: getSortedMessage(sellMessage.content, timeText),
           })
 
           await createMessage(historyMessage, history)
@@ -137,8 +143,11 @@ export default function setup(client: Client, historyChannelId: string, region: 
         newMessage = await newMessage.fetch()
       }
 
-      history[messageIndex].date = extractTimestamp(newMessage.content)
-      history[messageIndex].text = newMessage.content
+      const match = getTimestampMatch(newMessage.content)
+      const timeText = extractTimeText(match)
+      const timestamp = extractTimestamp(match)
+      history[messageIndex].date = timestamp
+      history[messageIndex].text = getSortedMessage(newMessage.content, timeText)
 
       await createMessage(historyMessage, history)
     }
@@ -161,11 +170,22 @@ function createMessage(historyMessage: Message<true>, history: HistoryMessage[])
   return historyMessage.edit(result)
 }
 
-function extractTimestamp(messageText: String) {
+function getTimestampMatch(messageText: string) {
   // Regex to match the timestamp pattern <t:number:format>
   const pattern = /<t:(\d+):[a-zA-Z]>/
-  const match = messageText.match(pattern)
+  return messageText.match(pattern)
+}
 
+function extractTimeText(match: RegExpMatchArray | null) {
+  if (match) {
+    // Extract the whole timestamp
+    return match[0]
+  } else {
+    return "0"
+  }
+}
+
+function extractTimestamp(match: RegExpMatchArray | null) {
   if (match) {
     // Extract the numeric part of the timestamp
     const timestamp = parseInt(match[1], 10)
@@ -173,6 +193,15 @@ function extractTimestamp(messageText: String) {
   } else {
     return 0
   }
+}
+
+function getSortedMessage(message: string, timeText: string) {
+  if (timeText === "0") {
+    // some weird input, do not manipulate text
+    return message
+  }
+  const messageWithoutTime = message.replace(timeText, '')
+  return timeText.trim() + " " + messageWithoutTime.trim()
 }
 
 type HistoryMessage = {

--- a/features/sell-history.ts
+++ b/features/sell-history.ts
@@ -181,7 +181,7 @@ function extractTimeText(match: RegExpMatchArray | null) {
     // Extract the whole timestamp
     return match[0]
   } else {
-    return "0"
+    return '0'
   }
 }
 
@@ -189,6 +189,7 @@ function extractTimestamp(match: RegExpMatchArray | null) {
   if (match) {
     // Extract the numeric part of the timestamp
     const timestamp = parseInt(match[1], 10)
+
     return timestamp
   } else {
     return 0
@@ -197,12 +198,13 @@ function extractTimestamp(match: RegExpMatchArray | null) {
 
 function getSortedMessage(message: string, timeText: string) {
   // Sort the content message to have the time at the beginning
-  if (timeText === "0") {
+  if (timeText === '0') {
     // some weird input, do not manipulate text
     return message
   }
+
   const messageWithoutTime = message.replace(timeText, '')
-  return timeText.trim() + " " + messageWithoutTime.trim()
+  return timeText.trim() + ' ' + messageWithoutTime.trim()
 }
 
 type HistoryMessage = {

--- a/features/sell-history.ts
+++ b/features/sell-history.ts
@@ -76,13 +76,13 @@ export default function setup(client: Client, historyChannelId: string, region: 
 
       if (sellChannels[message.channelId] && sellChannels[message.channelId].region === region) {
         if (message.content.includes('<t:')) {
-          const match = getTimestampMatch(sellMessage.content)
+          const match = getTimestampMatch(message.content)
           const timeText = extractTimeText(match)
           const timestamp = extractTimestamp(match)
           history.push({
-            id: sellMessage.id,
+            id: message.id,
             date: timestamp,
-            text: getSortedMessage(sellMessage.content, timeText),
+            text: getSortedMessage(message.content, timeText),
           })
 
           await createMessage(historyMessage, history)
@@ -196,6 +196,7 @@ function extractTimestamp(match: RegExpMatchArray | null) {
 }
 
 function getSortedMessage(message: string, timeText: string) {
+  // Sort the content message to have the time at the beginning
   if (timeText === "0") {
     // some weird input, do not manipulate text
     return message


### PR DESCRIPTION
Could not test in the grand scheme of things but I've set up an own test bot for js (it's been a long time lol) and there it seemed to work fine. Also I should get some sort of IDE man...

Target is to fix this to be consistent and always have time first:
![image](https://github.com/user-attachments/assets/ca26f94c-e9a5-4887-a699-806b1c804795)
