### PR TITLE
Feature: slash-commands for sell threads

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -1,10 +1,10 @@
-require('dotenv').config()
+// require('dotenv').config()
 import { Client, Events, GatewayIntentBits, Partials } from 'discord.js'
 
-import LoadCommands from './load-commands'
 import * as SetupSellHistory from './features/sell-schedule.ts'
 import * as SetupBuyerManagement from './features/buyer-management.ts'
 
+import LoadCommands from './load-commands'
 import MaxDebug from './onMessageCreateHooks/0.debug.js'
 import StartSellThread from './onMessageCreateHooks/1.startSellThread.ts'
 import ReplyAsGemini from './onMessageCreateHooks/2.replyAsGemini.js'
@@ -28,21 +28,22 @@ const client = new Client({
   ],
   partials: [Partials.Message, Partials.Channel, Partials.Reaction],
 })
-LoadCommands(client)
 
 let maxCounter = {
   value: 1,
 }
 
+LoadCommands(client)
+
 client.once('ready', () => {
   console.log(`Logged in as ${client.user?.tag}`)
 })
 
-// SetupSellHistory.default(client, '1263126224247717928', 'EU')
-// SetupSellHistory.default(client, '1263276208028778619', 'NA')
-// SetupBuyerManagement.default()
+SetupSellHistory.default(client, '1270000848239329290', ['NA', 'EU'])
+SetupSellHistory.default(client, '1263126224247717928', ['EU'])
+SetupSellHistory.default(client, '1263276208028778619', ['NA'])
+SetupBuyerManagement.default()
 
-/*
 client.on('messageCreate', async (message) => {
   if (message.author.bot || message.system) return
 
@@ -92,7 +93,6 @@ client.on('messageCreate', async (message) => {
 client.on('messageReactionAdd', async (reaction, user) => {
   await AddToThread(reaction, user)
 })
-*/
 
 client.on(Events.InteractionCreate, async (interaction) => {
   // can introduce another handling here later, when other interactions are added

--- a/bot.js
+++ b/bot.js
@@ -16,6 +16,8 @@ import HelloIAm from './onMessageCreateHooks/7.helloIAm.js'
 
 import AddToThread from './onMessageReactionAddHooks/0.addToThread.js'
 
+import YoinkSellSpot from './onInteractionHooks/yoink-sell-spot.ts'
+
 const TOKEN = process.env.TOKEN
 const client = new Client({
   intents: [
@@ -107,8 +109,19 @@ client.on('messageReactionAdd', async (reaction, user) => {
 })
 
 client.on(Events.InteractionCreate, async (interaction) => {
-  // can introduce another handling here later, when other interactions are added
-  if (!interaction.isChatInputCommand()) return
+  if (interaction.isButton()) {
+    try {
+      const id = interaction.customId
+
+      if (id === 'yoink-sell-spot') {
+        await YoinkSellSpot(client, interaction)
+        return
+      }
+    } catch (error) {
+      console.error(`Error while trying to perform button management.`)
+      return
+    }
+  } else if (interaction.isChatInputCommand()) {
   const command = interaction.client.commands.get(interaction.commandName)
 
   if (!command) {
@@ -130,6 +143,7 @@ client.on(Events.InteractionCreate, async (interaction) => {
         content: 'There was an error while executing this command!',
         ephemeral: true,
       })
+      }
     }
   }
 })

--- a/bot.js
+++ b/bot.js
@@ -110,41 +110,25 @@ client.on('messageReactionAdd', async (reaction, user) => {
 
 client.on(Events.InteractionCreate, async (interaction) => {
   if (interaction.isButton()) {
-    try {
-      const id = interaction.customId
+    const id = interaction.customId
 
-      if (id === 'yoink-sell-spot') {
-        await YoinkSellSpot(client, interaction)
-        return
-      }
-    } catch (error) {
-      console.error(`Error while trying to perform button management.`)
-      return
+    if (id === 'yoink-sell-spot') {
+      await YoinkSellSpot(interaction).catch(() => {
+        console.error(`Error while trying to perform button management.`)
+      })
     }
   } else if (interaction.isChatInputCommand()) {
-  const command = interaction.client.commands.get(interaction.commandName)
+    const command = interaction.client.commands.get(interaction.commandName)
 
-  if (!command) {
-    console.error(`No command matching ${interaction.commandName} was found.`)
-    return
-  }
-
-  try {
-    await command.execute(interaction)
-  } catch (error) {
-    console.error(error)
-    if (interaction.replied || interaction.deferred) {
-      await interaction.followUp({
-        content: 'There was an error while executing this command!',
-        ephemeral: true,
-      })
-    } else {
-      await interaction.reply({
-        content: 'There was an error while executing this command!',
-        ephemeral: true,
-      })
-      }
+    if (!command) {
+      console.error(`No command matching ${interaction.commandName} was found.`)
+      return
     }
+
+    await command.execute(interaction).catch((error) => {
+      console.error(`--- A custom command threw, ${interaction.commandName} ---`)
+      console.error(error)
+    })
   }
 })
 

--- a/commands/utility/backup.ts
+++ b/commands/utility/backup.ts
@@ -41,28 +41,28 @@ module.exports = {
 
     let backupPeople: string[] = []
 
-    if (reactions.values())
-      for (const reaction of reactions.values()) {
-        const emoji = reaction.emoji.name
-        let users
-        try {
-          users = await reaction.users.fetch()
-        } catch (error) {
-          console.error('Error fetching users for reaction:', error)
-          await interaction.reply({
-            content: 'Failed to fetch users for a reaction.',
-            ephemeral: true,
-          })
-          return
-        }
-        switch (emoji) {
-          case 'MCBU':
-            backupPeople.push(...users.keys())
-            break
-          default:
-            break
-        }
+    if (reactions.values()) {
+      let users
+
+      const reaction = reactions.get('MCBU')
+
+      if (!reaction) {
+        return
       }
+
+      try {
+        users = await reaction.users.fetch()
+      } catch (error) {
+        console.error('Error fetching users for reaction:', error)
+        await interaction.reply({
+          content: 'Failed to fetch users for a reaction.',
+          ephemeral: true,
+        })
+        return
+      }
+
+      backupPeople.push(...users.keys())
+    }
 
     const messageText = `Aye, a backup is needed!\n${formatMentions(backupPeople)}`
     await interaction.reply({ content: messageText, ephemeral: false })

--- a/commands/utility/backup.ts
+++ b/commands/utility/backup.ts
@@ -1,4 +1,4 @@
-import { SlashCommandBuilder, ThreadChannel, Message, CommandInteraction } from 'discord.js'
+import { SlashCommandBuilder, ThreadChannel, Message, CommandInteraction, userMention } from 'discord.js'
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -64,14 +64,11 @@ module.exports = {
         }
       }
 
-    let messageText = ''
-
-    messageText += `Aye, a backup is needed!\n${formatMentions(backupPeople)}`
-
+    const messageText = `Aye, a backup is needed!\n${formatMentions(backupPeople)}`
     await interaction.reply({ content: messageText, ephemeral: false })
   },
 }
 
 function formatMentions(userIds: string[]) {
-  return userIds.map((id) => `<@${id}>`).join(' ')
+  return userIds.map((id) => userMention(id)).join(' ')
 }

--- a/commands/utility/backup.ts
+++ b/commands/utility/backup.ts
@@ -41,10 +41,10 @@ module.exports = {
 
     let backupPeople: string[] = []
 
-    if (reactions.values()) {
+    if (filteredReactions.values()) {
       let users
 
-      const reaction = reactions.get('MCBU')
+      let reaction = filteredReactions.at(0)
 
       if (!reaction) {
         return

--- a/commands/utility/backup.ts
+++ b/commands/utility/backup.ts
@@ -44,7 +44,7 @@ module.exports = {
     if (filteredReactions.values()) {
       let users
 
-      let reaction = filteredReactions.at(0)
+      const reaction = filteredReactions.at(0)
 
       if (!reaction) {
         return

--- a/commands/utility/backup.ts
+++ b/commands/utility/backup.ts
@@ -1,0 +1,77 @@
+import { SlashCommandBuilder, ThreadChannel, Message, CommandInteraction } from 'discord.js'
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('backup')
+    .setDescription('Pings the backups for the corresponding sell. Only works in the sell thread.'),
+  async execute(interaction: CommandInteraction) {
+    if (!(interaction.channel instanceof ThreadChannel)) {
+      await interaction.reply({
+        content: 'This channel is not a thread! Command only works in the corresponding sell thread.',
+        ephemeral: true,
+      })
+      return
+    }
+
+    let originalMessage: Message | null = null
+    try {
+      originalMessage = await interaction.channel.fetchStarterMessage()
+    } catch (error) {
+      console.error('Error fetching starter message:', error)
+      await interaction.reply({
+        content: 'Failed to fetch the original message.',
+        ephemeral: true,
+      })
+    }
+    if (!originalMessage) {
+      return
+    }
+
+    const reactions = originalMessage.reactions.cache
+    const relevantEmojis = ['MCBU']
+    const filteredReactions = reactions.filter((reaction) => relevantEmojis.includes(reaction.emoji.name!))
+
+    if (filteredReactions.size === 0) {
+      await interaction.reply({
+        content: 'There are sadly no backups signed up for this sell.',
+        ephemeral: true,
+      })
+      return
+    }
+
+    let backupPeople: string[] = []
+
+    if (reactions.values())
+      for (const reaction of reactions.values()) {
+        const emoji = reaction.emoji.name
+        let users
+        try {
+          users = await reaction.users.fetch()
+        } catch (error) {
+          console.error('Error fetching users for reaction:', error)
+          await interaction.reply({
+            content: 'Failed to fetch users for a reaction.',
+            ephemeral: true,
+          })
+          return
+        }
+        switch (emoji) {
+          case 'MCBU':
+            backupPeople.push(...users.keys())
+            break
+          default:
+            break
+        }
+      }
+
+    let messageText = ''
+
+    messageText += `Aye, a backup is needed!\n${formatMentions(backupPeople)}`
+
+    await interaction.reply({ content: messageText, ephemeral: false })
+  },
+}
+
+function formatMentions(userIds: string[]) {
+  return userIds.map((id) => `<@${id}>`).join(' ')
+}

--- a/commands/utility/sellinfo.ts
+++ b/commands/utility/sellinfo.ts
@@ -1,0 +1,99 @@
+import { SlashCommandBuilder, ThreadChannel, Message, CommandInteraction } from 'discord.js'
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('sellinfo')
+    .setDescription('Posts the sign-up for the corresponding sell. Only works in the sell thread.'),
+  async execute(interaction: CommandInteraction) {
+    const interactionUser = interaction.user.id
+    if (!(interaction.channel instanceof ThreadChannel)) {
+      await interaction.reply({
+        content: 'This channel is not a thread! Command only works in the corresponding sell thread.',
+        ephemeral: true,
+      })
+      return
+    }
+
+    let originalMessage: Message | null = null
+    try {
+      originalMessage = await interaction.channel.fetchStarterMessage()
+    } catch (error) {
+      console.error('Error fetching starter message:', error)
+      await interaction.reply({
+        content: 'Failed to fetch the original message.',
+        ephemeral: true,
+      })
+    }
+    if (!originalMessage) {
+      return
+    }
+
+    const reactions = originalMessage.reactions.cache
+    const relevantEmojis = ['MCMysticCoin', 'MCBU', 'MCUNSURE']
+    const filteredReactions = reactions.filter((reaction) => relevantEmojis.includes(reaction.emoji.name!))
+
+    if (filteredReactions.size === 0) {
+      await interaction.reply({
+        content: 'No relevant reactions found on the original message.',
+        ephemeral: true,
+      })
+      return
+    }
+
+    let signedPeople: string[] = []
+    let backupPeople: string[] = []
+    let unsurePeople: string[] = []
+
+    for (const reaction of reactions.values()) {
+      const emoji = reaction.emoji.name
+      let users
+      try {
+        users = await reaction.users.fetch()
+      } catch (error) {
+        console.error('Error fetching users for reaction:', error)
+        await interaction.reply({
+          content: 'Failed to fetch users for a reaction.',
+          ephemeral: true,
+        })
+        return
+      }
+      switch (emoji) {
+        case 'MCMysticCoin':
+          signedPeople.push(...users.keys())
+          break
+        case 'MCBU':
+          backupPeople.push(...users.keys())
+          break
+        case 'MCUNSURE':
+          unsurePeople.push(...users.keys())
+          break
+        default:
+          break
+      }
+    }
+
+    let messageText = ''
+
+    if (signedPeople.includes(interactionUser)) {
+      messageText += '**You are signed up!**\n'
+    } else if (backupPeople.includes(interactionUser)) {
+      messageText += '**You are signed up as a backup!**\n'
+    } else if (unsurePeople.includes(interactionUser)) {
+      messageText += '**You are signed up as unsure!**\n'
+    } else {
+      messageText += '**You are not signed up at all!**\n'
+    }
+    messageText += '\n'
+
+    messageText += `Main roster (${signedPeople.length}): ${formatMentions(signedPeople)}\n`
+    messageText += `Backup (${backupPeople.length}): ${formatMentions(backupPeople)}\n`
+    if (unsurePeople.length > 0) {
+      messageText += `Unsure (${unsurePeople.length}): ${formatMentions(unsurePeople)}\n`
+    }
+    await interaction.reply({ content: messageText, ephemeral: true })
+  },
+}
+
+function formatMentions(userIds: string[]) {
+  return userIds.map((id) => `<@${id}>`).join(', ')
+}

--- a/commands/utility/sellinfo.ts
+++ b/commands/utility/sellinfo.ts
@@ -1,4 +1,4 @@
-import { SlashCommandBuilder, ThreadChannel, Message, CommandInteraction } from 'discord.js'
+import { SlashCommandBuilder, ThreadChannel, Message, CommandInteraction, userMention } from 'discord.js'
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -95,5 +95,5 @@ module.exports = {
 }
 
 function formatMentions(userIds: string[]) {
-  return userIds.map((id) => `<@${id}>`).join(', ')
+  return userIds.map((id) => userMention(id)).join(', ')
 }

--- a/commands/utility/sellinfo.ts
+++ b/commands/utility/sellinfo.ts
@@ -46,13 +46,7 @@ module.exports = {
     let backupPeople: string[] = []
     let unsurePeople: string[] = []
 
-    const validReactions = [
-      reactions.get(relevantEmojis[0]),
-      reactions.get(relevantEmojis[1]),
-      reactions.get(relevantEmojis[2]),
-    ]
-
-    for (const reaction of validReactions) {
+    for (const reaction of filteredReactions.values()) {
       if (!reaction) {
         continue
       }

--- a/commands/utility/signoff.ts
+++ b/commands/utility/signoff.ts
@@ -1,4 +1,13 @@
-import { SlashCommandBuilder, ThreadChannel, Message, CommandInteraction } from 'discord.js'
+import {
+  SlashCommandBuilder,
+  ThreadChannel,
+  Message,
+  CommandInteraction,
+  ButtonBuilder,
+  ButtonStyle,
+  userMention,
+  ActionRowBuilder,
+} from 'discord.js'
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -111,5 +120,5 @@ module.exports = {
 }
 
 function formatMentions(userIds: string[]) {
-  return userIds.map((id) => `<@${id}>`).join(', ')
+  return userIds.map((id) => userMention(id)).join(', ')
 }

--- a/commands/utility/signoff.ts
+++ b/commands/utility/signoff.ts
@@ -1,0 +1,115 @@
+import { SlashCommandBuilder, ThreadChannel, Message, CommandInteraction } from 'discord.js'
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('signoff')
+    .setDescription('Signs you off from a sell and pings the backups to yoink. Only works in the sell thread.'),
+  async execute(interaction: CommandInteraction) {
+    const interactionUser = interaction.user.id
+    if (!(interaction.channel instanceof ThreadChannel)) {
+      await interaction.reply({
+        content: 'This channel is not a thread! Command only works in the corresponding sell thread.',
+        ephemeral: true,
+      })
+      return
+    }
+
+    let originalMessage: Message | null = null
+    try {
+      originalMessage = await interaction.channel.fetchStarterMessage()
+    } catch (error) {
+      console.error('Error fetching starter message:', error)
+      await interaction.reply({
+        content: 'Failed to fetch the original message.',
+        ephemeral: true,
+      })
+    }
+    if (!originalMessage) {
+      return
+    }
+
+    const reactions = originalMessage.reactions.cache
+    const relevantEmojis = ['MCMysticCoin', 'MCBU']
+    const filteredReactions = reactions.filter((reaction) => relevantEmojis.includes(reaction.emoji.name!))
+
+    if (filteredReactions.size === 0) {
+      await interaction.reply({
+        content: 'No relevant reactions found on the original message.',
+        ephemeral: true,
+      })
+      return
+    }
+
+    const hasSignUps = filteredReactions.some((reaction) => reaction.emoji.name === 'MCMysticCoin')
+    const hasBackups = filteredReactions.some((reaction) => reaction.emoji.name === 'MCBU')
+
+    if (!hasSignUps) {
+      await interaction.reply({
+        content: 'You are not even signed up, dumbo.',
+        ephemeral: true,
+      })
+      return
+    }
+    if (!hasBackups) {
+      await interaction.reply({
+        content:
+          'Sadly, no backups were found for this sell. Cannot ping any backups. If you still want to sign off, manually do so and communicate it.',
+        ephemeral: true,
+      })
+      return
+    }
+
+    let backupPeople: string[] = []
+
+    for (const reaction of filteredReactions.values()) {
+      const emoji = reaction.emoji.name
+      let users
+      try {
+        users = await reaction.users.fetch()
+      } catch (error) {
+        console.error('Error fetching users for reaction:', error)
+        await interaction.reply({
+          content: 'Failed to fetch users for a reaction.',
+          ephemeral: true,
+        })
+        return
+      }
+      switch (emoji) {
+        case 'MCMysticCoin':
+          if (!users.has(interactionUser)) {
+            await interaction.reply({
+              content: 'You are not even signed up, dumbo.',
+              ephemeral: true,
+            })
+            return
+          }
+          // remove MCMysticCoin reaction from user that prompted the command
+          try {
+            await reaction.users.remove(interactionUser)
+          } catch (error) {
+            console.error('Cannot remove reaction from user:', error)
+            await interaction.reply({
+              content: 'Could not remove your reaction. Someone check bot permissions.',
+              ephemeral: true,
+            })
+            return
+          }
+          break
+        case 'MCBU':
+          backupPeople.push(...users.keys())
+          break
+        default:
+          break
+      }
+    }
+
+    let messageText = `<@${interactionUser}> signed off for this sell. Go yoink!\n\n`
+    messageText += `${formatMentions(backupPeople)}`
+
+    await interaction.reply({ content: messageText, ephemeral: false })
+  },
+}
+
+function formatMentions(userIds: string[]) {
+  return userIds.map((id) => `<@${id}>`).join(', ')
+}

--- a/commands/utility/signoff.ts
+++ b/commands/utility/signoff.ts
@@ -112,10 +112,15 @@ module.exports = {
       }
     }
 
-    let messageText = `<@${interactionUser}> signed off for this sell. Go yoink!\n\n`
+    let messageText = `${userMention(interactionUser)} signed off for this sell.\n\nGo yoink!\n`
+    const yoinkButton = new ButtonBuilder()
+      .setCustomId('yoink-sell-spot')
+      .setLabel('Yoink')
+      .setStyle(ButtonStyle.Success)
+    const buttonRow = new ActionRowBuilder<ButtonBuilder>().addComponents(yoinkButton)
     messageText += `${formatMentions(backupPeople)}`
 
-    await interaction.reply({ content: messageText, ephemeral: false })
+    await interaction.reply({ content: messageText, components: [buttonRow], ephemeral: false })
   },
 }
 

--- a/commands/utility/signoff.ts
+++ b/commands/utility/signoff.ts
@@ -24,6 +24,7 @@ module.exports = {
     }
 
     let originalMessage: Message | null = null
+
     try {
       originalMessage = await interaction.channel.fetchStarterMessage()
     } catch (error) {
@@ -33,6 +34,7 @@ module.exports = {
         ephemeral: true,
       })
     }
+
     if (!originalMessage) {
       return
     }
@@ -73,6 +75,7 @@ module.exports = {
     for (const reaction of filteredReactions.values()) {
       const emoji = reaction.emoji.name
       let users
+
       try {
         users = await reaction.users.fetch()
       } catch (error) {
@@ -83,6 +86,7 @@ module.exports = {
         })
         return
       }
+
       switch (emoji) {
         case 'MCMysticCoin':
           if (!users.has(interactionUser)) {
@@ -112,12 +116,13 @@ module.exports = {
       }
     }
 
-    let messageText = `${userMention(interactionUser)} signed off for this sell.\n\nGo yoink!\n`
     const yoinkButton = new ButtonBuilder()
       .setCustomId('yoink-sell-spot')
       .setLabel('Yoink')
       .setStyle(ButtonStyle.Success)
     const buttonRow = new ActionRowBuilder<ButtonBuilder>().addComponents(yoinkButton)
+
+    let messageText = `${userMention(interactionUser)} signed off for this sell.\n\nGo yoink!\n`
     messageText += `${formatMentions(backupPeople)}`
 
     await interaction.reply({ content: messageText, components: [buttonRow], ephemeral: false })

--- a/constants/translations.ts
+++ b/constants/translations.ts
@@ -83,12 +83,12 @@ Your selections have been registered. What would you like to do next?
     french: `**__Etape 4 : Actions supplémentaires__** 👣 
 Tes selections ont ete enregistrées. Que veux-tu faire ensuite?
 
-🔹 **Contactez-nous** : Envoyez-nous une notification si vous avez des questions ou si vous souhaitez acheter quelque chose.
+🔹 **Contacte-nous**: Envoie-nous une notification si t'as des questions ou si tu veux acheter quelque chose.
 🔹 **Retour**: Reviens au début pour explorer plus d'options.`,
     spanish: `**__Ultimo Paso: Proximas opciones__** 👣 
 Tus selecciones han sido registradas. Que te gustaria hacer ahora?
 
-🔹 **Contacte con nosotros**: Envíenos una notificación si tiene alguna pregunta o desea comprar algo.
+🔹 **Contacta nos**: Envíenos una notificación si tienes algunas preguntas o deseas comprar algo.
 🔹 **Regresar**: regresa al principio para explorar otras opciones.`,
     german: `**__Letzter Schritt:  Checkout__** 👣
 Deine Auswahl wurde registriert. Was würdest du gerne als nächstes tun?
@@ -98,8 +98,8 @@ Deine Auswahl wurde registriert. Was würdest du gerne als nächstes tun?
   },
   contact_us: {
     english: 'Contact us',
-    french: 'Contactez-nous',
-    spanish: 'Contacte con nosotros',
+    french: 'Contacte-nous',
+    spanish: 'Contacta nos',
     german: 'Kontaktiere uns',
   },
   return: {

--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -1,0 +1,47 @@
+// https://discordjs.guide/creating-your-bot/command-deployment.html#guild-commands
+const { REST, Routes } = require('discord.js')
+const fs = require('node:fs')
+const path = require('node:path')
+require('dotenv').config()
+const TOKEN = process.env.TOKEN
+
+const commands = []
+// Grab all the command folders from the commands directory you created earlier
+const foldersPath = path.join(__dirname, 'commands')
+const commandFolders = fs.readdirSync(foldersPath)
+
+for (const folder of commandFolders) {
+  // Grab all the command files from the commands directory you created earlier
+  const commandsPath = path.join(foldersPath, folder)
+  const commandFiles = fs.readdirSync(commandsPath).filter((file) => file.endsWith('.js') || file.endsWith('.ts'))
+  // Grab the SlashCommandBuilder#toJSON() output of each command's data for deployment
+  for (const file of commandFiles) {
+    const filePath = path.join(commandsPath, file)
+    const command = require(filePath)
+    if ('data' in command && 'execute' in command) {
+      commands.push(command.data.toJSON())
+    } else {
+      console.log(`[WARNING] The command at ${filePath} is missing a required "data" or "execute" property.`)
+    }
+  }
+}
+
+// Construct and prepare an instance of the REST module
+const rest = new REST({ version: 10 }).setToken(TOKEN)
+
+// and deploy your commands!
+;(async () => {
+  try {
+    console.log(`Started refreshing ${commands.length} application (/) commands.`)
+
+    // The put method is used to fully refresh all commands in the guild with the current set
+    const data = await rest.put(Routes.applicationGuildCommands(process.env.CLIENT_ID, process.env.GUILD_ID), {
+      body: commands,
+    })
+
+    console.log(`Successfully reloaded ${data.length} application (/) commands.`)
+  } catch (error) {
+    // And of course, make sure you catch and log any errors!
+    console.error(error)
+  }
+})()

--- a/load-commands.js
+++ b/load-commands.js
@@ -1,0 +1,22 @@
+const fs = require('node:fs')
+const path = require('node:path')
+const { Collection } = require('discord.js')
+
+export default function loadCommands(client) {
+  client.commands = new Collection()
+  const foldersPath = path.join(__dirname, 'commands')
+  const commandFolders = fs.readdirSync(foldersPath)
+  for (const folder of commandFolders) {
+    const commandsPath = path.join(foldersPath, folder)
+    const commandFiles = fs.readdirSync(commandsPath).filter((file) => file.endsWith('.js') || file.endsWith('.ts'))
+    for (const file of commandFiles) {
+      const filePath = path.join(commandsPath, file)
+      const command = require(filePath)
+      if ('data' in command && 'execute' in command) {
+        client.commands.set(command.data.name, command)
+      } else {
+        console.log(`[WARNING] The command at ${filePath} is missing a required "data" or "execute" property.`)
+      }
+    }
+  }
+}

--- a/onInteractionHooks/yoink-sell-spot.ts
+++ b/onInteractionHooks/yoink-sell-spot.ts
@@ -1,0 +1,25 @@
+import { Interaction, ButtonInteraction, userMention, Client } from 'discord.js'
+
+export default async function onYoinkSellSpot(client: Client, interaction: Interaction) {
+  const buttonInteraction = interaction as ButtonInteraction
+  const message = buttonInteraction.message
+
+  if (buttonInteraction.customId === 'yoink-sell-spot') {
+    if (!message.content.includes('Yoinked by')) {
+      await message.edit({
+        content: `~~${message.content}~~\r\nYoinked by ${userMention(interaction.user.id)}`,
+        components: [],
+      })
+
+      await buttonInteraction.reply({
+        content: 'You yoinked! Make sure to react manually to the post with the coin!',
+        ephemeral: true,
+      })
+    } else {
+      await buttonInteraction.reply({
+        content: 'It has already been yoinked. So close!',
+        ephemeral: true,
+      })
+    }
+  }
+}

--- a/onInteractionHooks/yoink-sell-spot.ts
+++ b/onInteractionHooks/yoink-sell-spot.ts
@@ -1,6 +1,6 @@
-import { Interaction, ButtonInteraction, userMention, Client } from 'discord.js'
+import { Interaction, ButtonInteraction, userMention } from 'discord.js'
 
-export default async function onYoinkSellSpot(client: Client, interaction: Interaction) {
+export default async function onYoinkSellSpot(interaction: Interaction) {
   const buttonInteraction = interaction as ButtonInteraction
   const message = buttonInteraction.message
 


### PR DESCRIPTION
This PR adds three slash commands, build for the main bot (best-aeon).

1. /sellinfo - Gives an overview of the signups while being in the thread
2. /backup - Pings all backups for the corresponding sell while being in the thread
3. /signoff - Removes MC reaction from user and pings all backups to yoink in the thread

To register these commands, you have to run deploy-commands.js with the correct parameters (TOKEN, CLIENT_ID and GUILD_ID, which it loads from the .env).